### PR TITLE
Fixed non-lock devices filtering

### DIFF
--- a/custom_components/airbnk_cloud/airbnk_api.py
+++ b/custom_components/airbnk_cloud/airbnk_api.py
@@ -170,7 +170,7 @@ class AirbnkApi:
 
         res = {}
         for dev_data in json_data["data"] or []:
-            if dev_data["gateway"] == "":
+            if not dev_data["boardModel"].isnumeric():
                 _LOGGER.info("Device '%s' is filtered out", dev_data["deviceName"])
             else:
                 res[dev_data["sn"]] = dev_data["deviceName"]


### PR DESCRIPTION
Non-lock devices (such as gateways and fingerprints) were filtered out using a wrong assumption. Fixed.